### PR TITLE
Cleaner battle info (0.5.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "battlemovr",
   "description": "A driver for RPG-like battles between two collections of actors.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "Josh Goldberg",
     "email": "joshuakgoldberg@outlook.com"

--- a/src/IBattleMovr.ts
+++ b/src/IBattleMovr.ts
@@ -13,13 +13,6 @@ export interface IGameStartr extends GameStartr.GameStartr {
 }
 
 /**
- * Menus available during battle, keyed by name.
- */
-export interface IBattleOptions {
-    [i: string]: IBattleOption;
-}
-
-/**
  * Description of a menu available during battle.
  */
 export interface IBattleOption {
@@ -31,47 +24,113 @@ export interface IBattleOption {
     /**
      * Text displayed in the options menu.
      */
-    text: (string | MenuGraphr.IMenuWordCommand)[];
+    text: MenuGraphr.IMenuDialogRaw;
 }
 
 /**
- * Names of known menus, such as those triggered by battle options.
+ * Names of known MenuGraphr menus.
  */
 export interface IMenuNames {
-    moves: string;
+    /**
+     * The primary backdrop battle menu.
+     */
+    battle: string;
+
+    /**
+     * The initial display when a battle starts.
+     */
+    battleDisplayInitial: string;
+
+    /**
+     * The player's options menu.
+     */
+    player: string;
+
+    /**
+     * General dialog text container.
+     */
+    generalText: string;
 }
 
+/**
+ * Positions of in-battle Things, keyed by name.
+ */
+export interface IPositions {
+    [i: string]: IPosition;
+}
+
+/**
+ * Position of an in-battle Thing.
+ */
 export interface IPosition {
+    /**
+     * The Thing's left.
+     */
     left?: number;
+
+    /**
+     * The Thing's top.
+     */
     top?: number;
 }
 
+/**
+ * A container for all in-battle Things.
+ */
 export interface IThingsContainer {
-    menu?: IThing;
-    [i: string]: IThing;
+    /**
+     * Any initial battle display menu.
+     */
+    menu?: GameStartr.IThing;
+
+    [i: string]: GameStartr.IThing;
 }
 
-export interface IThing extends GameStartr.IThing {
-    groupType: string;
-}
+/**
+ * Default settings for running a battle.
+ */
+export interface IBattleInfoDefaults {
+    /**
+     * A dialog to display after the battle.
+     */
+    exitDialog?: MenuGraphr.IMenuDialogRaw;
 
-export interface IMenu extends IThing { }
-
-export interface IBattleSettings {
-    nextCutscene: string;
-    nextCutsceneSettings: string;
-}
-
-export interface IBattleInfo {
-    exitDialog?: string;
-    items?: any;
+    /**
+     * A next cutscene to play after the battle.
+     */
     nextCutscene?: string;
-    nextCutsceneSettings?: any;
+
+    /**
+     * Any settings for the next cutscene.
+     */
+    nextCutsceneSettings?: ScenePlayr.ICutsceneSettings;
+
+    /**
+     * A next routine to play in a next cutscene.
+     */
     nextRoutine?: string;
+
+    /**
+     * Any settings for the next cutscene's routine.
+     */
     nextRoutineSettings?: any;
+
+    [i: string]: any;
+}
+
+/**
+ * Settings for running a battle.
+ */
+export interface IBattleInfo extends IBattleInfoDefaults {
+    /**
+     * The players controlling battling actors.
+     */
     battlers: IBattlers;
 }
 
+/**
+ * In-battle players controlling battling actors.
+ */
 export interface IBattlers {
     /**
      * The opponent battler's information.
@@ -86,95 +145,244 @@ export interface IBattlers {
     [i: /* "opponent" | "player" */ string]: IBattler;
 }
 
-export interface IBattleInfoDefaults {
-    exitDialog: string;
-}
-
+/**
+ * An in-battle player.
+ */
 export interface IBattler {
-    actors: IActor[];
+    /**
+     * Actors that may be sent out to battle.
+     */
+    actors?: IActor[];
+
+    /**
+     * The game-specific category of fighter, such as "Trainer" or "Wild".
+     */
     category: string;
+
+    /**
+     * Whether the player has actors, rather than fighting alone.
+     */
     hasActors?: boolean;
+
+    /**
+     * The name of the player.
+     */
     name: string[];
+
+    /**
+     * Which actor is currently selected to battle, if any.
+     */
     selectedActor?: IActor;
+
+    /**
+     * The index of the currently selected actor, if any.
+     */
     selectedIndex?: number;
+
+    /**
+     * A sprite name to send out to battle.
+     */
     sprite: string;
 }
 
+/**
+ * An actor that may be sent out in battle.
+ */
 export interface IActor {
-    Attack: number;
-    AttackNormal: number;
-    Defense: number;
-    DefenseNormal: number;
-    EV: {
-        Attack: number;
-        Defense: number;
-        Special: number;
-        Speed: number;
-    };
-    HP: number;
-    HPNormal: number;
-    IV: {
-        Attack: number;
-        Defense: number;
-        HP: number;
-        Special: number;
-        Speed: number;
-    };
-    Special: number;
-    SpecialNormal: number;
-    Speed: number;
-    SpeedNormal: number;
+    /**
+     * Experience points for leveling up.
+     */
     experience: IActorExperience;
+
+    /**
+     * The actor's current level.
+     */
     level: number;
+
+    /**
+     * Moves the actor knows.
+     */
     moves: IMove[];
-    nickname: string[];
-    status: string;
+
+    /**
+     * The primary title of the actor.
+     */
     title: string[];
-    types: string[];
 }
 
+/**
+ * An actor's experience points for leveling up.
+ */
 export interface IActorExperience {
+    /**
+     * Current amount of experience points.
+     */
     current: number;
+
+    /**
+     * How many experience points are needed for the next level.
+     */
     next: number;
-    remaining: number;
 }
 
+/**
+ * An actor's knowledge of a battle move.
+ */
 export interface IMove {
+    /**
+     * The name of the battle move.
+     */
     title: string;
+
+    /**
+     * How many uses are remaining.
+     */
     remaining: number;
+
+    /**
+     * How many total uses of this move are allowed.
+     */
+    uses: number;
 }
 
+/**
+ * Settings to initialize a new IBattleMovr instance.
+ */
 export interface IBattleMovrSettings {
+    /**
+     * The IGameStartr providing Thing and actor information.
+     */
     GameStarter: IGameStartr;
-    battleMenuName: string;
-    battleOptions: IBattleOptions;
+
+    /**
+     * Names of known MenuGraphr menus.
+     */
     menuNames: IMenuNames;
-    openItemsMenuCallback: (settings: any) => void;
-    openActorsMenuCallback: (settings: any) => void;
-    defaults?: any;
+
+    /**
+     * Option menus the player may select during battle.
+     */
+    battleOptions: IBattleOption[];
+
+    /**
+     * Default settings for running battles.
+     */
+    defaults?: IBattleInfoDefaults;
+
+    /**
+     * Default positions of in-battle Things.
+     */
+    positions?: IPositions;
+
+    /**
+     * The type of Thing to create and use as a background.
+     */
     backgroundType?: string;
-    positions?: any;
 }
 
 /**
  * A driver for RPG-like battles between two collections of actors.
  */
 export interface IBattleMovr {
+    /**
+     * @returns The IGameStartr providing Thing and actor information.
+     */
     getGameStarter(): IGameStartr;
-    getDefaults(): IBattleInfoDefaults;
-    getThings(): { [i: string]: IThing };
-    getThing(name: string): IThing;
+
+    /**
+     * @returns Names of known MenuGraphr menus.
+     */
     getMenuNames(): IMenuNames;
+
+    /**
+     * @returns Default settings for running battles.
+     */
+    getDefaults(): IBattleInfoDefaults;
+
+    /**
+     * @returns All in-battle Things.
+     */
+    getThings(): IThingsContainer;
+
+    /**
+     * @param name   A name of an in-battle Thing.
+     * @returns The named in-battle Thing.
+     */
+    getThing(name: string): GameStartr.IThing;
+
+    /**
+     * @returns Current settings for a running battle.
+     */
     getBattleInfo(): IBattleInfo;
-    getBackgroundType(): string;
-    getBackgroundThing(): IThing;
+
+    /**
+     * @returns Whether a battle is currently happening.
+     */
     getInBattle(): boolean;
-    startBattle(settings: IBattleSettings): void;
+
+    /**
+     * @returns The type of Thing to create and use as a background.
+     */
+    getBackgroundType(): string;
+
+    /**
+     * @returns The created Thing used as a background.
+     */
+    getBackgroundThing(): GameStartr.IThing;
+
+    /**
+     * Starts a battle.
+     * 
+     * @param settings   Settings for running the battle.
+     */
+    startBattle(settings: IBattleInfo): void;
+
+    /**
+     * Closes any current battle.
+     * 
+     * @param callback   A callback to run after the battle is closed.
+     * @remarks The callback will run after deleting menus but before the next cutscene.
+     */
     closeBattle(callback?: () => void): void;
+
+    /**
+     * Shows the player menu.
+     */
     showPlayerMenu(): void;
-    setThing(name: string, title: string, settings?: any): IThing;
+
+    /**
+     * Creates and displays an in-battle Thing.
+     * 
+     * @param name   The storage name of the Thing.
+     * @param title   The Thing's in-game type.
+     * @param settings   Any additional settings to create the Thing.
+     * @returns The created Thing.
+     */
+    setThing(name: string, title: string, settings?: any): GameStartr.IThing;
+
+    /**
+     * Starts a round of battle with a player's move.
+     * 
+     * @param choisePlayer   The player's move choice.
+     */
     playMove(choicePlayer: string): void;
-    switchActor(battlerName: string, i: number): void;
-    createBackground(): void;
+
+    /**
+     * Switches a battler's actor.
+     * 
+     * @param battlerName   The name of the battler.
+     */
+    switchActor(battlerName: "player" | "opponent", i: number): void;
+
+    /**
+     * Creates the battle background.
+     * 
+     * @param type   A type of background, if not the default.
+     */
+    createBackground(type?: string): void;
+
+    /**
+     * Deletes the battle background.
+     */
     deleteBackground(): void;
 }

--- a/src/IBattleMovr.ts
+++ b/src/IBattleMovr.ts
@@ -1,8 +1,44 @@
 /// <reference path="../typings/GameStartr.d.ts" />
 /// <reference path="../typings/MenuGraphr.d.ts" />
+/// <reference path="../typings/MapScreenr.d.ts" />
 
+/**
+ * Extended IGameStartr with menus.
+ */
 export interface IGameStartr extends GameStartr.GameStartr {
+    /**
+     * In-game menu and dialog creation and management for GameStartr.
+     */
     MenuGrapher: MenuGraphr.IMenuGraphr;
+}
+
+/**
+ * Menus available during battle, keyed by name.
+ */
+export interface IBattleOptions {
+    [i: string]: IBattleOption;
+}
+
+/**
+ * Description of a menu available during battle.
+ */
+export interface IBattleOption {
+    /**
+     * A callback that opens the menu.
+     */
+    callback: () => void;
+
+    /**
+     * Text displayed in the options menu.
+     */
+    text: (string | MenuGraphr.IMenuWordCommand)[];
+}
+
+/**
+ * Names of known menus, such as those triggered by battle options.
+ */
+export interface IMenuNames {
+    moves: string;
 }
 
 export interface IPosition {
@@ -33,15 +69,28 @@ export interface IBattleInfo {
     nextCutsceneSettings?: any;
     nextRoutine?: string;
     nextRoutineSettings?: any;
-    opponent?: IBattleThingInfo;
-    player?: IBattleThingInfo;
+    battlers: IBattlers;
+}
+
+export interface IBattlers {
+    /**
+     * The opponent battler's information.
+     */
+    opponent?: IBattler;
+
+    /**
+     * The player's battle information.
+     */
+    player?: IBattler;
+
+    [i: /* "opponent" | "player" */ string]: IBattler;
 }
 
 export interface IBattleInfoDefaults {
     exitDialog: string;
 }
 
-export interface IBattleThingInfo {
+export interface IBattler {
     actors: IActor[];
     category: string;
     hasActors?: boolean;
@@ -98,8 +147,8 @@ export interface IMove {
 export interface IBattleMovrSettings {
     GameStarter: IGameStartr;
     battleMenuName: string;
-    battleOptionNames: string;
-    menuNames: string;
+    battleOptions: IBattleOptions;
+    menuNames: IMenuNames;
     openItemsMenuCallback: (settings: any) => void;
     openActorsMenuCallback: (settings: any) => void;
     defaults?: any;
@@ -112,8 +161,10 @@ export interface IBattleMovrSettings {
  */
 export interface IBattleMovr {
     getGameStarter(): IGameStartr;
+    getDefaults(): IBattleInfoDefaults;
     getThings(): { [i: string]: IThing };
     getThing(name: string): IThing;
+    getMenuNames(): IMenuNames;
     getBattleInfo(): IBattleInfo;
     getBackgroundType(): string;
     getBackgroundThing(): IThing;
@@ -122,12 +173,8 @@ export interface IBattleMovr {
     closeBattle(callback?: () => void): void;
     showPlayerMenu(): void;
     setThing(name: string, title: string, settings?: any): IThing;
-    openMovesMenu(): void;
-    openItemsMenu(): void;
-    openActorsMenu(callback: (settings: any) => void): void;
     playMove(choicePlayer: string): void;
     switchActor(battlerName: string, i: number): void;
-    startBattleExit(): void;
     createBackground(): void;
     deleteBackground(): void;
 }


### PR DESCRIPTION
`battleInfo` now contains a `.battlers` to clean up those ugly `any` casts in FSP.

Everything has JSDocs.

Moved some FSP-specific logic to FSP.

Made some privates protected in anticipation of FSP having its own subclass.